### PR TITLE
Fix the documented return type of \Horde_Mime_Mail::getRaw

### DIFF
--- a/lib/Horde/Mime/Mail.php
+++ b/lib/Horde/Mime/Mail.php
@@ -488,7 +488,7 @@ class Horde_Mime_Mail
      * @param  boolean $stream  If true, return a stream resource, otherwise
      *                          a string is returned.
      *
-     * @return stream|string  The raw email data.
+     * @return resource|string  The raw email data.
      * @since 2.4.0
      */
     public function getRaw($stream = true)


### PR DESCRIPTION
As reported by Psalm :pray: 

@yunosh @mrubinsk would it be possible to have this released afterwards together with https://github.com/horde/Mime/commit/d4dccdce16bbc14d98d418a4b50747ff5ae419ae? :)