### PR TITLE
getContents() quoted-printable EOL patch

### DIFF
--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -426,6 +426,7 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
                 return $this->_writeStream(base64_decode(stream_get_contents($fp)));
 
             case 'quoted-printable':
+                $fp = $this->replaceEOL($fp, self::RFC_EOL);
                 try {
                     return $this->_writeStream($fp, array(
                         'error' => true,


### PR DESCRIPTION
I've found a bug in getContents() when part is encoded with quoted-printable.

When calling Horde_Mime_Part::parseMessage() at the beginning all EOL characters are converted to CR instead of CRLF but unfortunately it messes quoted-printable encoding which required CRLF.
As it states in comments CR is required internally so I've added additional backwards conversion only to stream contents of parts encoded to quoted-printable.
When using Horde_Mime_Part::getRawPartText() which for some reason uses CRLF I can manually decode quoted-printable just fine without any other conversions.

I've run several test and it's working fine.

Simple test case:

```
$part = Horde_Mime_Part::parseMessage(file_get_contents('test.eml'));
$p = $part['1.2'];

$stream = $p->getContents([
    'stream' => true
]);
rewind($stream);
header('Content-Type: image/png');
fpassthru($stream);
fclose($stream);
```

Assuming that test.eml is test email message and in 1.2 part is image encoded with quoted-printable.