### PR TITLE
Fix string replace with null (PHP8.1)

### DIFF
--- a/lib/Horde/Mime/Headers/Element.php
+++ b/lib/Horde/Mime/Headers/Element.php
@@ -142,6 +142,9 @@ implements IteratorAggregate
         }
 
         /* Ensure no null characters exist in header data. */
+		if ($data === null) {
+			return '';
+		}
         return str_replace("\0", '', $data);
     }
 


### PR DESCRIPTION
Fixes ``PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /home/runner/work/Imap_Client/Imap_Client/vendor/bytestream/horde-mime/lib/Horde/Mime/Headers/Element.php on line 145``