### PR TITLE
Backport: Upgrade serialization for PHP 8.1

### DIFF
--- a/doc/Horde/Mime/changelog.yml
+++ b/doc/Horde/Mime/changelog.yml
@@ -1,4 +1,15 @@
 ---
+2.11.2:
+  api: 2.11.0
+  state:
+    release: stable
+    api: stable
+  date: 2020-10-14
+  license:
+    identifier: LGPL-2.1
+    uri: http://www.horde.org/licenses/lgpl21
+  notes: |
+    [mjr] Silence deprecation notices for PHP 8.1 tentative return types (PR #4).
 2.11.1:
   api: 2.11.0
   state:

--- a/lib/Horde/Mime/Headers.php
+++ b/lib/Horde/Mime/Headers.php
@@ -398,6 +398,40 @@ implements ArrayAccess, IteratorAggregate, Serializable
 
         return serialize($data);
     }
+    /**
+     * Serialization.
+     *
+     * @return array  Serialized data.
+     */
+    public function __serialize(): array
+    {
+        $data = array(
+            // Serialized data ID.
+            self::VERSION,
+            $this->_headers->getArrayCopy(),
+            // TODO: BC
+            $this->_eol
+        );
+        return $data;
+    }
+
+    /**
+     * Unserialization.
+     *
+     * @param array $data  Serialized data.
+     *
+     * @throws Horde_Mime_Exception
+     */
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data[0]) || ($data[0] != self::VERSION)) {
+            throw new Horde_Mime_Exception('Cache version change');
+        }
+
+        $this->_headers = new Horde_Support_CaseInsensitiveArray($data[1]);
+        // TODO: BC
+        $this->_eol = $data[2];
+    }
 
     /**
      * Unserialization.

--- a/lib/Horde/Mime/Headers/ContentParam.php
+++ b/lib/Horde/Mime/Headers/ContentParam.php
@@ -401,6 +401,9 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
     /* Serializable methods */
 
     /**
+     * Serialize (until PHP 7.3)
+     * 
+     * @return string serialized object state
      */
     public function serialize()
     {
@@ -412,6 +415,43 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
     }
 
     /**
+     * Serialize (PHP 7.4+)
+     *
+     * @return array object state
+     */
+    public function __serialize(): array
+    {
+        $vars = array_filter(get_object_vars($this));
+        if (isset($vars['_params'])) {
+            $vars['_params'] = $vars['_params']->getArrayCopy();
+        }
+        return $vars;
+    }
+
+    /**
+     * Unserialize (PHP 7.4+)
+     * 
+     * @param array $data
+     */
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $key => $val) {
+            switch ($key) {
+            case '_params':
+                $this->_params = new Horde_Support_CaseInsensitiveArray($val);
+                break;
+
+            default:
+                $this->$key = $val;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Unserialize (until PHP 7.3)
+     * 
+     * @param string $data
      */
     public function unserialize($data)
     {

--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -2414,6 +2414,62 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
         return serialize($data);
     }
 
+
+    public function __serialize(): array
+    {
+        $data = array(
+            // Serialized data ID.
+            self::VERSION,
+            $this->_bytes,
+            $this->_eol,
+            $this->_hdrCharset,
+            $this->_headers,
+            $this->_metadata,
+            $this->_mimeid,
+            $this->_parts,
+            $this->_status,
+            $this->_transferEncoding
+        );
+
+        if (!empty($this->_contents)) {
+            $data[] = $this->_readStream($this->_contents);
+        }
+        return $data;
+    }
+    public function __unserialize(array $data): void
+    {
+        if (!isset($data[0]) || ($data[0] != self::VERSION)) {
+            switch ($data[0]) {
+            case 1:
+                $convert = new Horde_Mime_Part_Upgrade_V1($data);
+                $data = $convert->data;
+                break;
+
+            default:
+                $data = null;
+                break;
+            }
+
+            if (is_null($data)) {
+                throw new Exception('Cache version change');
+            }
+        }
+
+        $key = 0;
+        $this->_bytes = $data[++$key];
+        $this->_eol = $data[++$key];
+        $this->_hdrCharset = $data[++$key];
+        $this->_headers = $data[++$key];
+        $this->_metadata = $data[++$key];
+        $this->_mimeid = $data[++$key];
+        $this->_parts = $data[++$key];
+        $this->_status = $data[++$key];
+        $this->_transferEncoding = $data[++$key];
+
+        if (isset($data[++$key])) {
+            $this->setContents($data[$key]);
+        }
+    }
     /**
      * Unserialization.
      *


### PR DESCRIPTION
 - new code path runs on PHP 7.3+ instead of serialize / unserialize
 - old codepath runs on older PHP
 - no deprecation warning on PHP 8.1+