### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/lib/Horde/Mime/Headers/ContentParam.php
+++ b/lib/Horde/Mime/Headers/ContentParam.php
@@ -230,7 +230,7 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
     protected function _escapeParams($params)
     {
         foreach ($params as $k => $v) {
-            foreach (str_split($v) as $c) {
+            foreach (mb_str_split($v) as $c) {
                 if (!Horde_Mime_ContentParam_Decode::isAtextNonTspecial($c)) {
                     $params[$k] = '"' . addcslashes($v, '\\"') . '"';
                     break;


### PR DESCRIPTION
In PHP 8.2, the str_split function will returns empty arrays for empty strings.
See: https://php.watch/versions/8.2/str_split-empty-string-empty-array

We can use mb_str_split() instead
