### PR TITLE
Prevent infinite loop

### DIFF
--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -2160,6 +2160,7 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
             /* Boundary needs to appear at beginning of string or right after
              * a LF. */
             if (($pos != 0) && ($text[$pos - 1] != "\n")) {
+		$pos++;
                 continue;
             }
 


### PR DESCRIPTION
If a boundary not preceded by a newline is present in the middle of the content an infinite loop is generated.