### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Horde/Mime/Headers.php
+++ b/lib/Horde/Mime/Headers.php
@@ -384,9 +384,9 @@ implements ArrayAccess, IteratorAggregate, Serializable
     /**
      * Serialization.
      *
-     * @return string  Serialized data.
+     * @return array Serializable data.
      */
-    public function serialize()
+    public function __serialize()
     {
         $data = array(
             // Serialized data ID.
@@ -396,7 +396,37 @@ implements ArrayAccess, IteratorAggregate, Serializable
             $this->_eol
         );
 
-        return serialize($data);
+        return $data;
+    }
+
+    /**
+     * Serialization.
+     *
+     * @return string  Serialized data.
+     */
+    public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * Unserialization.
+     *
+     * @param array $data  Unserializable data.
+     *
+     * @throws Exception
+     */
+    public function __unserialize($data)
+    {
+        if (!is_array($data) ||
+            !isset($data[0]) ||
+            ($data[0] != self::VERSION)) {
+            throw new Horde_Mime_Exception('Cache version change');
+        }
+
+        $this->_headers = new Horde_Support_CaseInsensitiveArray($data[1]);
+        // TODO: BC
+        $this->_eol = $data[2];
     }
 
     /**
@@ -409,15 +439,7 @@ implements ArrayAccess, IteratorAggregate, Serializable
     public function unserialize($data)
     {
         $data = @unserialize($data);
-        if (!is_array($data) ||
-            !isset($data[0]) ||
-            ($data[0] != self::VERSION)) {
-            throw new Horde_Mime_Exception('Cache version change');
-        }
-
-        $this->_headers = new Horde_Support_CaseInsensitiveArray($data[1]);
-        // TODO: BC
-        $this->_eol = $data[2];
+        $this->__unserialize($data);
     }
 
     /* ArrayAccess methods. */

--- a/lib/Horde/Mime/Headers/ContentParam.php
+++ b/lib/Horde/Mime/Headers/ContentParam.php
@@ -402,21 +402,27 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
 
     /**
      */
-    public function serialize()
+    public function __serialize()
     {
         $vars = array_filter(get_object_vars($this));
         if (isset($vars['_params'])) {
             $vars['_params'] = $vars['_params']->getArrayCopy();
         }
-        return serialize($vars);
+        return $vars;
+    }
+
+
+    /**
+     */
+    public function serialize()
+    {
+        return serialize($this->__serialize());
     }
 
     /**
      */
-    public function unserialize($data)
+    public function __unserialize($data)
     {
-        $data = unserialize($data);
-
         foreach ($data as $key => $val) {
             switch ($key) {
             case '_params':
@@ -428,6 +434,14 @@ implements ArrayAccess, Horde_Mime_Headers_Extension_Mime, Serializable
                 break;
             }
         }
+    }
+
+    /**
+     */
+    public function unserialize($data)
+    {
+        $data = unserialize($data);
+        $this->__unserialize($data);
     }
 
 }

--- a/lib/Horde/Mime/Mdn.php
+++ b/lib/Horde/Mime/Mdn.php
@@ -157,7 +157,7 @@ class Horde_Mime_Mdn
                              array $err = array())
     {
         $opts = array_merge(array(
-            'charset' => null,
+            'charset' => 'UTF-8',
             'from_addr' => null
         ), $opts);
 

--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -2389,9 +2389,9 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
     /**
      * Serialization.
      *
-     * @return string  Serialized data.
+     * @return array  Serializable data.
      */
-    public function serialize()
+    public function __serialize()
     {
         $data = array(
             // Serialized data ID.
@@ -2411,19 +2411,28 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
             $data[] = $this->_readStream($this->_contents);
         }
 
-        return serialize($data);
+        return $data;
+    }
+
+    /**
+     * Serialization.
+     *
+     * @return string  Serialized data.
+     */
+    public function serialize()
+    {
+        return serialize($this->__serialize());
     }
 
     /**
      * Unserialization.
      *
-     * @param string $data  Serialized data.
+     * @param array $data  Unserializable data.
      *
      * @throws Exception
      */
-    public function unserialize($data)
+    public function __unserialize($data)
     {
-        $data = @unserialize($data);
         if (!is_array($data) ||
             !isset($data[0]) ||
             ($data[0] != self::VERSION)) {
@@ -2457,6 +2466,19 @@ implements ArrayAccess, Countable, RecursiveIterator, Serializable
         if (isset($data[++$key])) {
             $this->setContents($data[$key]);
         }
+    }
+
+    /**
+     * Unserialization.
+     *
+     * @param string $data  Serialized data.
+     *
+     * @throws Exception
+     */
+    public function unserialize($data)
+    {
+	$data = @unserialize($data);
+        $this->__unserialize($data);
     }
 
     /* Deprecated elements. */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Horde/Mime/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Horde/Mime/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Mime Unit Tests">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Horde/Mime/ContentParam/DecodeTest.php
+++ b/test/Horde/Mime/ContentParam/DecodeTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_ContentParam_DecodeTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_ContentParam_DecodeTest extends Horde_Test_Case
 {
     /**
      * @dataProvider decodeProvider

--- a/test/Horde/Mime/ContentParamTest.php
+++ b/test/Horde/Mime/ContentParamTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_ContentParamTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_ContentParamTest extends Horde_Test_Case
 {
     /**
      * @dataProvider encodeProvider

--- a/test/Horde/Mime/Headers/ContentDispositionTest.php
+++ b/test/Horde/Mime/Headers/ContentDispositionTest.php
@@ -21,7 +21,7 @@
  * @subpackage UnitTests
  */
 class Horde_Mime_Headers_ContentDispositionTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     /**
      * @dataProvider parsingOfInputProvider

--- a/test/Horde/Mime/Headers/ContentIdTest.php
+++ b/test/Horde/Mime/Headers/ContentIdTest.php
@@ -21,7 +21,7 @@
  * @subpackage UnitTests
  */
 class Horde_Mime_Headers_ContentIdTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     /**
      * @dataProvider valueProvider

--- a/test/Horde/Mime/Headers/ContentLanguageTest.php
+++ b/test/Horde/Mime/Headers/ContentLanguageTest.php
@@ -21,7 +21,7 @@
  * @subpackage UnitTests
  */
 class Horde_Mime_Headers_ContentLanguageTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     /**
      * @dataProvider parsingOfInputProvider

--- a/test/Horde/Mime/Headers/ContentTransferEncodingTest.php
+++ b/test/Horde/Mime/Headers/ContentTransferEncodingTest.php
@@ -21,7 +21,7 @@
  * @subpackage UnitTests
  */
 class Horde_Mime_Headers_ContentTransferEncodingTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     /**
      * @dataProvider valuesProvider

--- a/test/Horde/Mime/Headers/ContentTypeTest.php
+++ b/test/Horde/Mime/Headers/ContentTypeTest.php
@@ -21,7 +21,7 @@
  * @subpackage UnitTests
  */
 class Horde_Mime_Headers_ContentTypeTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     /**
      * @dataProvider parsingOfInputProvider

--- a/test/Horde/Mime/HeadersTest.php
+++ b/test/Horde/Mime/HeadersTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_HeadersTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_HeadersTest extends Horde_Test_Case
 {
     public function testClone()
     {
@@ -90,6 +90,7 @@ class Horde_Mime_HeadersTest extends PHPUnit_Framework_TestCase
 
     public function serializeProvider()
     {
+        $this->expectNotToPerformAssertions();
         return array(
             array(
                 'Subject', 'My Subject'
@@ -314,13 +315,11 @@ class Horde_Mime_HeadersTest extends PHPUnit_Framework_TestCase
         );
 
         /* @deprecated */
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $hdrs->getValue('content-type', Horde_Mime_Headers::VALUE_BASE)
         );
 
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $hdrs['content-type']->value
         );
     }
@@ -631,8 +630,7 @@ class Horde_Mime_HeadersTest extends PHPUnit_Framework_TestCase
         $hdrs = Horde_Mime_Headers::parseHeaders($data);
 
         /* @deprecated */
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $hdrs->getValue($header, Horde_Mime_Headers::VALUE_BASE)
         );
         $this->assertEquals(
@@ -640,8 +638,7 @@ class Horde_Mime_HeadersTest extends PHPUnit_Framework_TestCase
             $hdrs->getValue($header)
         );
 
-        $this->assertInternalType(
-            'string',
+        $this->assertIsString(
             $hdrs[$header]->value_single
         );
         $this->assertEquals(
@@ -688,6 +685,8 @@ class Horde_Mime_HeadersTest extends PHPUnit_Framework_TestCase
     {
         $hdrs = new Horde_Mime_Headers();
 
+        // dummy assertion to silence PHPUnit and marking this test as "risky"
+        $this->assertTrue(true);
         try {
             $hdrs->addHeaderOb($ob, true);
             if (!$valid) {

--- a/test/Horde/Mime/MagicTest.php
+++ b/test/Horde/Mime/MagicTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_MagicTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_MagicTest extends Horde_Test_Case
 {
     /**
      * @requires extension fileinfo

--- a/test/Horde/Mime/MailTest.php
+++ b/test/Horde/Mime/MailTest.php
@@ -20,15 +20,15 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_MailTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_MailTest extends Horde_Test_Case
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         $_SERVER['SERVER_NAME'] = 'mail.example.com';
         setlocale(LC_ALL, 'C');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         unset($_SERVER['SERVER_NAME']);
         setlocale(LC_ALL, '');

--- a/test/Horde/Mime/MailTest.php
+++ b/test/Horde/Mime/MailTest.php
@@ -46,7 +46,7 @@ class Horde_Mime_MailTest extends Horde_Test_Case
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -84,7 +84,7 @@ MIME-Version: 1.0',
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -123,7 +123,7 @@ MIME-Version: 1.0',
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: =?iso-8859-1?b?U2No9m5lcg==?= Betreff
@@ -180,7 +180,7 @@ Content-Transfer-Encoding: quoted-printable',
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -237,7 +237,7 @@ bHRlciBEZWljaC4K
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -274,7 +274,7 @@ MIME-Version: 1.0',
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -308,7 +308,7 @@ MIME-Version: 1.0',
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -369,7 +369,7 @@ Content-Description: HTML Version of Message
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -441,15 +441,15 @@ end
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent1 = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent1 = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $mail->addHeader('To', 'recipient2@example.com');
         $mail->send($dummy);
-        $sent2 = str_replace("\r\n", "\n", $dummy->sentMessages[1]);
+        $sent2 = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[1])), true);
 
         $mail->setBody("This is\nanother body");
         $mail->send($dummy);
-        $sent3 = str_replace("\r\n", "\n", $dummy->sentMessages[2]);
+        $sent3 = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[2])), true);
 
         $hdrs1 = Horde_Mime_Headers::parseHeaders($sent1['header_text']);
         $hdrs2 = Horde_Mime_Headers::parseHeaders($sent2['header_text']);
@@ -482,7 +482,7 @@ end
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertStringMatchesFormat(
 'Subject: My Subject
@@ -527,7 +527,7 @@ id est laborum.
 
         $dummy = new Horde_Mail_Transport_Mock();
         $mail->send($dummy);
-        $sent = str_replace("\r\n", "\n", $dummy->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($dummy->sentMessages[0])), true);
 
         $this->assertEquals(
             '',

--- a/test/Horde/Mime/Mdn/NonTranslatedTest.php
+++ b/test/Horde/Mime/Mdn/NonTranslatedTest.php
@@ -92,7 +92,7 @@ class Horde_Mime_Mdn_NonTranslatedTest extends Horde_Test_Case
 'This message is in MIME format.
 
 --=%s
-Content-Type: text/plain; format=flowed; DelSp=Yes
+Content-Type: text/plain; charset=utf-8; format=flowed; DelSp=Yes
 
 The message sent on Tue, 18 Nov 2014 20:14:17 -0700 to BAR  
 <bar@example.com> with subject "Test" has been displayed.

--- a/test/Horde/Mime/Mdn/NonTranslatedTest.php
+++ b/test/Horde/Mime/Mdn/NonTranslatedTest.php
@@ -20,17 +20,17 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_Mdn_NonTranslatedTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_Mdn_NonTranslatedTest extends Horde_Test_Case
 {
     private $oldlocale;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->oldlocale = setlocale(LC_MESSAGES, 0);
         setlocale(LC_MESSAGES, 'C');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         setlocale(LC_MESSAGES, $this->oldlocale);
     }

--- a/test/Horde/Mime/Mdn/NonTranslatedTest.php
+++ b/test/Horde/Mime/Mdn/NonTranslatedTest.php
@@ -69,7 +69,7 @@ class Horde_Mime_Mdn_NonTranslatedTest extends Horde_Test_Case
             array('error' => 'Foo')
         );
 
-        $sent = str_replace("\r\n", "\n", $mailer->sentMessages[0]);
+        $sent = json_decode(str_replace("\r\n", "\n", json_encode($mailer->sentMessages[0])), true);
 
         $this->assertEquals(
             'auto-replied',

--- a/test/Horde/Mime/MdnTest.php
+++ b/test/Horde/Mime/MdnTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_MdnTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_MdnTest extends Horde_Test_Case
 {
     /**
      * @dataProvider getMdnReturnAddrProvider

--- a/test/Horde/Mime/MimeIdTest.php
+++ b/test/Horde/Mime/MimeIdTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_MimeIdTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_MimeIdTest extends Horde_Test_Case
 {
     public function testToString()
     {

--- a/test/Horde/Mime/MimeTest.php
+++ b/test/Horde/Mime/MimeTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_MimeTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_MimeTest extends Horde_Test_Case
 {
     /**
      * @dataProvider is8bitProvider

--- a/test/Horde/Mime/PartTest.php
+++ b/test/Horde/Mime/PartTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_PartTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_PartTest extends Horde_Test_Case
 {
     public function testParseMessage()
     {
@@ -420,8 +420,7 @@ class Horde_Mime_PartTest extends PHPUnit_Framework_TestCase
             $part1->getAllContentTypeParameters()
         );
 
-        $this->assertInternalType(
-            'resource',
+        $this->assertIsResource(
             $part1->getContents(array('stream' => true))
         );
 
@@ -1033,7 +1032,7 @@ Test.
         return $part;
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         Horde_Mime_Part::$defaultCharset =
             Horde_Mime_Headers::$defaultCharset = 'us-ascii';

--- a/test/Horde/Mime/RelatedTest.php
+++ b/test/Horde/Mime/RelatedTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_RelatedTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_RelatedTest extends Horde_Test_Case
 {
     /**
      * @dataProvider startProvider

--- a/test/Horde/Mime/UudecodeTest.php
+++ b/test/Horde/Mime/UudecodeTest.php
@@ -20,7 +20,7 @@
  * @package    Mime
  * @subpackage UnitTests
  */
-class Horde_Mime_UudecodeTest extends PHPUnit_Framework_TestCase
+class Horde_Mime_UudecodeTest extends Horde_Test_Case
 {
     /**
      * @dataProvider uudecodeProvider

--- a/test/Horde/Mime/phpunit.xml
+++ b/test/Horde/Mime/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian changes: Adapt to PHPUnit 8.x and 9.x API. https://salsa.debian.org/horde-team/php-horde-mime/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: PHP 8.0 fixes https://salsa.debian.org/horde-team/php-horde-mime/-/blob/debian-sid/debian/patches/1020_php-80.patch
- Debian changes: Use UTF-8 as default encoding, not null https://salsa.debian.org/horde-team/php-horde-mime/-/blob/debian-sid/debian/patches/1021_php-80-enforce-utf8-as-default-charset.patch
- Debian changes: 1022_php8.1.patch
