### PR TITLE
Do not split long boundary

### DIFF
--- a/lib/Horde/Mime/Headers/ContentParam.php
+++ b/lib/Horde/Mime/Headers/ContentParam.php
@@ -178,7 +178,7 @@ class Horde_Mime_Headers_ContentParam extends Horde_Mime_Headers_Element_Single 
             ++$pre_len;
         }
 
-        if (($pre_len + strlen($string)) > 75) {
+        if ($name != 'boundary' && ($pre_len + strlen($string)) > 75) {
             /* Account for continuation '*'. */
             ++$pre_len;
             $wrap = true;


### PR DESCRIPTION
long boundary are currently split and this break messages.
I known RFC 2046 does not allow boundary to be more than 70 char but here is an exemple with 66 chars.

A message header with
```
Content-Type: multipart/mixed; boundary="----=_=-_OpenGroupware_org_NGMime-26739-1764058188.613387-49------"
```
become
```
Content-Type: multipart/mixed;
 boundary*0="----=_=-_OpenGroupware_org_NGMime-26739-1764058188.613387-49----";
 boundary*1=--
```
And the mail become invalid.

With this patch:
```
Content-Type: multipart/mixed;
 boundary="----=_=-_OpenGroupware_org_NGMime-26739-1764058188.613387-49------"
```