### PR TITLE
feat: Replace dead pear/net_dns2 with PHP 8.x compatible

### DIFF
--- a/.horde.yml
+++ b/.horde.yml
@@ -48,12 +48,12 @@ dependencies:
     composer:
       horde/nls: ^3
       horde/text_filter: ^3
-      pear/net_dns2: ^1.5.3
+      mikepultz/netdns2: ^2.0
   dev:
     composer:
       horde/nls: ^3
       horde/test: ^3
       horde/text_filter: ^3
-      pear/net_dns2: ^1.5.3
+      mikepultz/netdns2: ^2.0
     ext:
       intl: '*'

--- a/composer.json
+++ b/composer.json
@@ -35,13 +35,13 @@
         "horde/nls": "^3 || dev-FRAMEWORK_6_0",
         "horde/test": "^3 || dev-FRAMEWORK_6_0",
         "horde/text_filter": "^3 || dev-FRAMEWORK_6_0",
-        "pear/net_dns2": "^1.5.3",
+        "mikepultz/netdns2": "^2.0",
         "ext-intl": "*"
     },
     "suggest": {
         "horde/nls": "^3 || dev-FRAMEWORK_6_0",
         "horde/text_filter": "^3 || dev-FRAMEWORK_6_0",
-        "pear/net_dns2": "^1.5.3"
+        "mikepultz/netdns2": "^2.0"
     },
     "autoload": {
         "psr-0": {

--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -1573,15 +1573,6 @@ class Horde_Mime_Part implements ArrayAccess, Countable, RecursiveIterator, Seri
         if (isset($opts['encode'])) {
             /* Always allow 7bit encoding. */
             $encode |= $opts['encode'];
-        } elseif ($mailer instanceof Horde_Mail_Transport_Smtp) {
-            try {
-                $smtp_ext = $mailer->getSMTPObject()->getServiceExtensions();
-                if (isset($smtp_ext['8BITMIME'])) {
-                    $encode |= self::ENCODE_8BIT;
-                }
-            } catch (Horde_Mail_Exception $e) {
-            }
-            $canonical = false;
         } elseif ($mailer instanceof Horde_Mail_Transport_Smtphorde) {
             try {
                 if ($mailer->getSMTPObject()->data_8bit) {
@@ -1612,13 +1603,6 @@ class Horde_Mime_Part implements ArrayAccess, Countable, RecursiveIterator, Seri
                 'Content-Transfer-Encoding',
                 $this->_temp['toString']
             );
-            switch ($this->_temp['toString']) {
-                case '8bit':
-                    if ($mailer instanceof Horde_Mail_Transport_Smtp) {
-                        $mailer->addServiceExtensionParameter('BODY', '8BITMIME');
-                    }
-                    break;
-            }
         }
 
         $this->_status = $old_status;


### PR DESCRIPTION
The mikepultz/netdns2 library is a php 8.x friendly replacement for pear/net_dns2 which is unmaintained and a source of notices
