### PR TITLE
Fix php deprecations and move tests to phpunit12+

### DIFF
--- a/lib/Horde/Mime/Part.php
+++ b/lib/Horde/Mime/Part.php
@@ -1134,7 +1134,7 @@ class Horde_Mime_Part implements ArrayAccess, Countable, RecursiveIterator, Seri
     {
         if (!empty($this->_temp['sendEncoding'])) {
             return $this->_temp['sendEncoding'];
-        } elseif (!empty($this->_temp['sendTransferEncoding'][$encode])) {
+	} elseif (isset($this->_temp['sendTransferEncoding']['encode']) && $this->_temp['sendTransferEncoding']['encode'] !== '') {
             return $this->_temp['sendTransferEncoding'][$encode];
         }
 
@@ -1204,7 +1204,9 @@ class Horde_Mime_Part implements ArrayAccess, Countable, RecursiveIterator, Seri
             }
         }
 
-        $this->_temp['sendTransferEncoding'][$encode] = $encoding;
+	if (isset($this->_temp['sendTransferEncoding']['encode']) && $this->_temp['sendTransferEncoding']['encode'] !== '') {
+        	$this->_temp['sendTransferEncoding'][$encode] = $encoding;
+	}
 
         return $encoding;
     }

--- a/test/Unnamespaced/ContentParam/DecodeTest.php
+++ b/test/Unnamespaced/ContentParam/DecodeTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced\ContentParam;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_ContentParam_Decode;
 
 /**
@@ -32,6 +33,7 @@ class DecodeTest extends TestCase
     /**
      * @dataProvider decodeProvider
      */
+    #[DataProvider('decodeProvider')]
     public function testDecode($string, $expected)
     {
         $decode = new Horde_Mime_ContentParam_Decode();

--- a/test/Unnamespaced/ContentParamTest.php
+++ b/test/Unnamespaced/ContentParamTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers_ContentParam;
 
 /**
@@ -32,6 +33,7 @@ class ContentParamTest extends TestCase
     /**
      * @dataProvider encodeProvider
      */
+    #[DataProvider('encodeProvider')]
     public function testEncode($params, $opts, $expected)
     {
         $cp = new Horde_Mime_Headers_ContentParam('NOT_USED', $params);
@@ -120,6 +122,7 @@ class ContentParamTest extends TestCase
     /**
      * @dataProvider decodeProvider
      */
+    #[DataProvider('decodeProvider')]
     public function testDecode($in, $val_expected, $params_expected)
     {
         $cp = new Horde_Mime_Headers_ContentParam('NOT_USED', $in);

--- a/test/Unnamespaced/Filter/EncodingTest.php
+++ b/test/Unnamespaced/Filter/EncodingTest.php
@@ -15,6 +15,7 @@
 
 namespace Horde\Mime\Test\Unnamespaced\Filter;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Test_Case;
 use stdClass;
 
@@ -35,6 +36,7 @@ class EncodingTest extends Horde_Test_Case
     /**
      * @dataProvider bodyFilterProvider()
      */
+    #[DataProvider('bodyFilterProvider')]
     public function testBodyFilter($data, $result)
     {
         $params = new stdClass();

--- a/test/Unnamespaced/Headers/ContentDispositionTest.php
+++ b/test/Unnamespaced/Headers/ContentDispositionTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced\Headers;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers_ContentParam_ContentDisposition;
 
 /**
@@ -32,6 +33,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider parsingOfInputProvider
      */
+    #[DataProvider('parsingOfInputProvider')]
     public function testParsingOfInput($input, $expected_val, $expected_params)
     {
         $ob = new Horde_Mime_Headers_ContentParam_ContentDisposition(
@@ -105,6 +107,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider fullValueProvider
      */
+    #[DataProvider('fullValueProvider')]
     public function testFullValue($value, $params, $expected)
     {
         $ob = new Horde_Mime_Headers_ContentParam_ContentDisposition(
@@ -198,6 +201,7 @@ class ContentDispositionTest extends TestCase
     /**
      * @dataProvider isDefaultProvider
      */
+    #[DataProvider('isDefaultProvider')]
     public function testIsDefault($value, $is_default)
     {
         $ob = new Horde_Mime_Headers_ContentParam_ContentDisposition(

--- a/test/Unnamespaced/Headers/ContentIdTest.php
+++ b/test/Unnamespaced/Headers/ContentIdTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced\Headers;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers_ContentId;
 
 /**
@@ -32,6 +33,7 @@ class ContentIdTest extends TestCase
     /**
      * @dataProvider valueProvider
      */
+    #[DataProvider('valueProvider')]
     public function testValue($input, $expected_val)
     {
         $ob = new Horde_Mime_Headers_ContentId(null, $input);

--- a/test/Unnamespaced/Headers/ContentLanguageTest.php
+++ b/test/Unnamespaced/Headers/ContentLanguageTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced\Headers;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers_ContentLanguage;
 
 /**
@@ -32,6 +33,7 @@ class ContentLanguageTest extends TestCase
     /**
      * @dataProvider parsingOfInputProvider
      */
+    #[DataProvider('parsingOfInputProvider')]
     public function testParsingOfInput($input, $expected_val, $expected_langs)
     {
         $ob = new Horde_Mime_Headers_ContentLanguage(null, $input);

--- a/test/Unnamespaced/Headers/ContentTransferEncodingTest.php
+++ b/test/Unnamespaced/Headers/ContentTransferEncodingTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced\Headers;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers_ContentTransferEncoding;
 
 /**
@@ -32,6 +33,7 @@ class ContentTransferEncodingTest extends TestCase
     /**
      * @dataProvider valuesProvider
      */
+    #[DataProvider('valuesProvider')]
     public function testValues($input, $expected_val, $is_default)
     {
         $ob = new Horde_Mime_Headers_ContentTransferEncoding(null, $input);

--- a/test/Unnamespaced/Headers/ContentTypeTest.php
+++ b/test/Unnamespaced/Headers/ContentTypeTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced\Headers;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers_ContentParam_ContentType;
 
 /**
@@ -32,6 +33,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider parsingOfInputProvider
      */
+    #[DataProvider('parsingOfInputProvider')]
     public function testParsingOfInput($input, $expected_val, $expected_params)
     {
         $ob = new Horde_Mime_Headers_ContentParam_ContentType(
@@ -164,6 +166,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider parsingContentTypeValueProvider
      */
+    #[DataProvider('parsingContentTypeValueProvider')]
     public function testParsingContentTypeValue($value, $primary, $sub)
     {
         $ob = Horde_Mime_Headers_ContentParam_ContentType::create();
@@ -208,6 +211,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider typeCharsetPropertyProvider
      */
+    #[DataProvider('typeCharsetPropertyProvider')]
     public function testTypeCharsetProperty($value, $charset, $expected)
     {
         $ob = Horde_Mime_Headers_ContentParam_ContentType::create();
@@ -244,6 +248,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider multipartPartsHaveBoundary
      */
+    #[DataProvider('multipartPartsHaveBoundary')]
     public function testMultipartPartsHaveBoundary($value, $has_boundary)
     {
         $ob = Horde_Mime_Headers_ContentParam_ContentType::create();
@@ -277,6 +282,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider charsetIsLowercaseProvider
      */
+    #[DataProvider('charsetIsLowercaseProvider')]
     public function testCharsetIsLowercase($charset, $expected)
     {
         $ob = Horde_Mime_Headers_ContentParam_ContentType::create();
@@ -322,6 +328,7 @@ class ContentTypeTest extends TestCase
     /**
      * @dataProvider isDefaultProvider
      */
+    #[DataProvider('isDefaultProvider')]
     public function testIsDefault($value, $is_default)
     {
         $ob = new Horde_Mime_Headers_ContentParam_ContentType(

--- a/test/Unnamespaced/HeadersTest.php
+++ b/test/Unnamespaced/HeadersTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Headers;
 use Horde_Mime_Headers_ContentParam_ContentType;
 use Horde_Mime_Headers_ContentParam_ContentDisposition;
@@ -82,6 +83,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider serializeProvider
      */
+    #[DataProvider('serializeProvider')]
     public function testSerialize($header, $value)
     {
         $hdrs = new Horde_Mime_Headers();
@@ -125,6 +127,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider normalHeaderDecodeProvider
      */
+    #[DataProvider('normalHeaderDecodeProvider')]
     public function testNormalHeaderDecode($header, $value, $decoded)
     {
         $hdrs = new Horde_Mime_Headers();
@@ -171,6 +174,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider contentParamHeaderDecodeProvider
      */
+    #[DataProvider('contentParamHeaderDecodeProvider')]
     public function testContentParamHeaderDecode(
         $header,
         $value,
@@ -221,6 +225,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider headerAutoDetectCharsetProvider
      */
+    #[DataProvider('headerAutoDetectCharsetProvider')]
     public function testHeaderAutoDetectCharset($header, $value, $decoded)
     {
         $hdrs = Horde_Mime_Headers::parseHeaders($value);
@@ -252,6 +257,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider headerEncodeProvider
      */
+    #[DataProvider('headerEncodeProvider')]
     public function testHeaderEncode(
         $header,
         $values,
@@ -342,6 +348,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider multivalueHeadersProvider
      */
+    #[DataProvider('multivalueHeadersProvider')]
     public function testMultivalueHeaders($header, $in, $expected)
     {
         $hdrs = Horde_Mime_Headers::parseHeaders($in);
@@ -379,6 +386,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider addHeaderWithGroupProvider
      */
+    #[DataProvider('addHeaderWithGroupProvider')]
     public function testAddHeaderWithGroup($header, $email)
     {
         $rfc822 = new Horde_Mail_Rfc822();
@@ -412,6 +420,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider unencodeMimeHeaderProvider
      */
+    #[DataProvider('unencodeMimeHeaderProvider')]
     public function testUnencodedMimeHeader($header, $in, $decoded)
     {
         $hdrs = Horde_Mime_Headers::parseHeaders($in);
@@ -443,6 +452,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider parseContentDispositionHeaderWithUtf8DataProvider
      */
+    #[DataProvider('parseContentDispositionHeaderWithUtf8DataProvider')]
     public function testParseContentDispositionHeaderWithUtf8Data(
         $header,
         $parameter,
@@ -553,6 +563,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider undisclosedHeaderParsingProvider
      */
+    #[DataProvider('undisclosedHeaderParsingProvider')]
     public function testUndisclosedHeaderParsing($header, $value)
     {
         $hdrs = new Horde_Mime_Headers();
@@ -642,6 +653,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider multiplePriorityHeadersProvider
      */
+    #[DataProvider('multiplePriorityHeadersProvider')]
     public function testMultiplePriorityHeaders($header, $data, $value)
     {
         $hdrs = Horde_Mime_Headers::parseHeaders($data);
@@ -698,6 +710,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider addHeaderObProvider
      */
+    #[DataProvider('addHeaderObProvider')]
     public function testAddHeaderOb($ob, $valid)
     {
         $hdrs = new Horde_Mime_Headers();
@@ -730,6 +743,7 @@ class HeadersTest extends TestCase
     /**
      * @dataProvider headerGenerationProvider
      */
+    #[DataProvider('headerGenerationProvider')]
     public function testHeaderGeneration($label, $data, $class)
     {
         $hdrs = new Horde_Mime_Headers();

--- a/test/Unnamespaced/MdnTest.php
+++ b/test/Unnamespaced/MdnTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mail_Rfc822;
 use Horde_Mime_Headers;
 use Horde_Mime_Mdn;
@@ -34,6 +35,7 @@ class MdnTest extends TestCase
     /**
      * @dataProvider getMdnReturnAddrProvider
      */
+    #[DataProvider('getMdnReturnAddrProvider')]
     public function testGetMdnReturnAddr($email)
     {
         $h = new Horde_Mime_Headers();
@@ -67,6 +69,7 @@ class MdnTest extends TestCase
     /**
      * @dataProvider UserConfirmationNeededProvider
      */
+    #[DataProvider('UserConfirmationNeededProvider')]
     public function testUserConfirmationNeeded($h, $expected)
     {
         $ob = new Horde_Mime_Mdn($h);

--- a/test/Unnamespaced/MimeIdTest.php
+++ b/test/Unnamespaced/MimeIdTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime_Id;
 
 /**
@@ -43,6 +44,7 @@ class MimeIdTest extends TestCase
     /**
      * @dataProvider idArithmeticProvider
      */
+    #[DataProvider('idArithmeticProvider')]
     public function testIdArithmetic($id, $action, $opts, $expected)
     {
         $id_ob = new Horde_Mime_Id($id);
@@ -134,6 +136,7 @@ class MimeIdTest extends TestCase
     /**
      * @dataProvider isChildProvider
      */
+    #[DataProvider('isChildProvider')]
     public function testIsChild($base, $id, $expected)
     {
         $id_ob = new Horde_Mime_Id($base);

--- a/test/Unnamespaced/MimeTest.php
+++ b/test/Unnamespaced/MimeTest.php
@@ -13,6 +13,7 @@
 namespace Horde\Mime\Test\Unnamespaced;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Horde_Mime;
 
 /**
@@ -32,6 +33,7 @@ class MimeTest extends TestCase
     /**
      * @dataProvider is8bitProvider
      */
+    #[DataProvider('is8bitProvider')]
     public function testIs8bit($data, $expected)
     {
         $this->assertEquals(
@@ -62,6 +64,7 @@ class MimeTest extends TestCase
     /**
      * @dataProvider decodeProvider
      */
+    #[DataProvider('decodeProvider')]
     public function testDecode($data, $expected)
     {
         $this->assertEquals(
@@ -115,6 +118,7 @@ class MimeTest extends TestCase
     /**
      * @dataProvider encodeProvider
      */
+    #[DataProvider('encodeProvider')]
     public function testEncode($data, $charset, $expected)
     {
         $this->assertEquals(

--- a/test/Unnamespaced/PartTest.php
+++ b/test/Unnamespaced/PartTest.php
@@ -15,6 +15,7 @@ namespace Horde\Mime\Test\Unnamespaced;
 use PHPUnit\Framework\TestCase;
 use Horde_Mime_Headers;
 use Horde_Mime_Part;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests for the Horde_Mime_Part class.
@@ -250,6 +251,7 @@ class PartTest extends TestCase
     /**
      * @dataProvider contentsTransferDecodingProvider
      */
+    #[DataProvider('contentsTransferDecodingProvider')]
     public function testContentsTransferDecoding($data, $encoding, $text)
     {
         $part = new Horde_Mime_Part();
@@ -287,6 +289,7 @@ class PartTest extends TestCase
     /**
      * @dataProvider setTypeProvider
      */
+    #[DataProvider('setTypeProvider')]
     public function testSetType($data, $type, $boundary)
     {
         $part = new Horde_Mime_Part();
@@ -389,6 +392,7 @@ class PartTest extends TestCase
     /**
      * @dataProvider setDispositionProvider
      */
+    #[DataProvider('setDispositionProvider')]
     public function testSetDisposition($disp)
     {
         $part = new Horde_Mime_Part();
@@ -689,6 +693,7 @@ C
     /**
      * @dataProvider setCharsetProvider
      */
+    #[DataProvider('setCharsetProvider')]
     public function testSetCharset($charset, $expected)
     {
         $part = new Horde_Mime_Part();

--- a/test/Unnamespaced/RelatedTest.php
+++ b/test/Unnamespaced/RelatedTest.php
@@ -15,6 +15,7 @@ namespace Horde\Mime\Test\Unnamespaced;
 use PHPUnit\Framework\TestCase;
 use Horde_Mime_Related;
 use Horde_Mime_Part;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests for the Horde_Mime_Related class.
@@ -33,6 +34,7 @@ class RelatedTest extends TestCase
     /**
      * @dataProvider startProvider
      */
+    #[DataProvider('startProvider')]
     public function testStart($ob, $id)
     {
         $this->assertEquals(
@@ -62,6 +64,7 @@ class RelatedTest extends TestCase
     /**
      * @dataProvider searchProvider
      */
+    #[DataProvider('searchProvider')]
     public function testSearch($ob, $search, $id)
     {
         $this->assertEquals(
@@ -93,6 +96,7 @@ class RelatedTest extends TestCase
     /**
      * @dataProvider iteratorProvider
      */
+    #[DataProvider('iteratorProvider')]
     public function testIterator($ob, $ids)
     {
         $this->assertEquals(

--- a/test/Unnamespaced/UudecodeTest.php
+++ b/test/Unnamespaced/UudecodeTest.php
@@ -14,6 +14,7 @@ namespace Horde\Mime\Test\Unnamespaced;
 
 use PHPUnit\Framework\TestCase;
 use Horde_Mime_Uudecode;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Tests for the Horde_Mime_Uudecode class.
@@ -32,6 +33,7 @@ class UudecodeTest extends TestCase
     /**
      * @dataProvider uudecodeProvider
      */
+    #[DataProvider('uudecodeProvider')]
     public function testUudecode($data, $expected)
     {
         $uudecode = new Horde_Mime_Uudecode($data);


### PR DESCRIPTION
This fixes php deprecation warnings and moves testing to phpunit12+ by adding #[DataProvider] entries.

@ralflang, @TDannhauer 